### PR TITLE
feat: Implementar timer persistente para la Tarea Mac

### DIFF
--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -57,6 +57,8 @@ export interface ReadingHistoryEntry {
   completedDate: string;
 }
 
+export type TimerState = 'running' | 'paused' | 'stopped';
+
 export interface DayState {
   date: string;
   currentTaskIndex: number;
@@ -64,6 +66,8 @@ export interface DayState {
   dayCompleted: boolean;
   subtaskQueues: { [taskId: string]: Subtask[] };
   readingHistory?: ReadingHistoryEntry[];
+  timerElapsedSeconds?: number;
+  timerState?: TimerState;
 }
 
 // Espacios disponibles para tareas y compras

--- a/frontend/src/pages/WeeklyPage.tsx
+++ b/frontend/src/pages/WeeklyPage.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { Box, Typography, Paper, Grid, Button, LinearProgress, Alert } from '@mui/material'
-import { CheckCircle, Start, SkipNext } from '@mui/icons-material'
+import { Start, SkipNext } from '@mui/icons-material'
 import { useWeeklyContext } from '@/contexts/WeeklyContext'
 import LoadingSpinner from '@/components/common/LoadingSpinner'
 import TaskTimer from '@/components/weekly/TaskTimer'
@@ -8,8 +8,23 @@ import ReadingTask from '@/components/weekly/ReadingTask'
 import GameTask from '@/components/weekly/GameTask'
 
 const WeeklyPage: React.FC = () => {
-  const { weeklyTasks, dayState, currentTask, loading, error, fetchWeeklyTasks, fetchCurrentDay, startTask, completeTask, completeSubtask, updateSubtaskTitle } = useWeeklyContext()
-  const [timerActive, setTimerActive] = useState(false)
+  const {
+    weeklyTasks,
+    dayState,
+    currentTask,
+    loading,
+    error,
+    fetchWeeklyTasks,
+    fetchCurrentDay,
+    startTask,
+    completeTask,
+    completeSubtask,
+    updateSubtaskTitle,
+    updateTimer,
+    pauseTimer,
+    resumeTimer,
+    tickTimer
+  } = useWeeklyContext()
 
   // Cargar datos al montar el componente
   useEffect(() => {
@@ -94,10 +109,7 @@ const WeeklyPage: React.FC = () => {
                       variant="contained"
                       startIcon={<Start />}
                       size="large"
-                      onClick={() => {
-                        startTask()
-                        setTimerActive(true)
-                      }}
+                      onClick={startTask}
                       disabled={loading}
                       color="primary"
                     >
@@ -128,13 +140,15 @@ const WeeklyPage: React.FC = () => {
                 </Box>
               </Paper>
 
-              {/* Timer - solo si la tarea está iniciada */}
-              {currentTask && currentTask.isStarted && (
+              {/* Timer - solo para la tarea 'Mac' y si está iniciada */}
+              {currentTask && currentTask.name === 'Mac' && currentTask.isStarted && dayState && dayState.timerState && (
                 <TaskTimer
                   taskName={currentTask.name}
-                  isActive={timerActive}
-                  onStart={() => setTimerActive(true)}
-                  onPause={() => setTimerActive(false)}
+                  elapsedSeconds={dayState.timerElapsedSeconds || 0}
+                  timerState={dayState.timerState}
+                  onTick={(newSeconds) => tickTimer(newSeconds)}
+                  onPause={pauseTimer}
+                  onResume={resumeTimer}
                   onComplete={completeTask}
                 />
               )}
@@ -142,7 +156,7 @@ const WeeklyPage: React.FC = () => {
               {/* Tarea de lectura especial */}
               {currentTask && currentTask.name.toLowerCase().includes('leer') && currentTask.isStarted && (
                 <ReadingTask
-                  isActive={timerActive}
+                  isActive={dayState?.timerState === 'running'}
                   subtask={currentTask.subtasks?.find(st => st.id === currentTask.currentSubtaskId)}
                   onUpdateTitle={(subtaskId, newTitle) => {
                     updateSubtaskTitle(subtaskId, newTitle);
@@ -153,7 +167,7 @@ const WeeklyPage: React.FC = () => {
               {/* Tarea de juego especial */}
               {currentTask && currentTask.name.toLowerCase() === 'juego' && currentTask.isStarted && (
                 <GameTask
-                  isActive={timerActive}
+                  isActive={dayState?.timerState === 'running'}
                   subtask={currentTask.subtasks?.find(st => st.id === currentTask.currentSubtaskId)}
                   onUpdateTitle={(subtaskId, newTitle) => {
                     updateSubtaskTitle(subtaskId, newTitle);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -257,6 +257,18 @@ export const weeklyService = {
     await api.post('/weekly/update-subtask-title', { subtaskId, newTitle });
   },
 
+  // Actualizar el estado del timer de la tarea Mac
+  async updateTimerState(elapsedSeconds: number, state: 'running' | 'paused' | 'stopped'): Promise<DayState> {
+    const response = await api.post<ApiResponse<{ dayState: DayState }>>('/weekly/timer', {
+      elapsedSeconds,
+      state,
+    });
+    if (!response.data.data) {
+      throw new Error('Error updating timer state');
+    }
+    return response.data.data.dayState;
+  },
+
   // Obtener progreso semanal
   async getProgress(): Promise<{
     totalTasks: number;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -51,12 +51,16 @@ export interface WeeklyTask {
   currentSubtaskId?: string; // ID de la subtarea activa
 }
 
+export type TimerState = 'running' | 'paused' | 'stopped';
+
 export interface DayState {
   date: string;
   currentTaskIndex: number;
   completedTasks: string[];
   dayCompleted: boolean;
   subtaskQueues: { [taskId: string]: Subtask[] };
+  timerElapsedSeconds?: number;
+  timerState?: TimerState;
 }
 
 // Espacios disponibles para tareas y compras
@@ -156,10 +160,14 @@ export interface WeeklyContextType {
   error: string | null;
   fetchWeeklyTasks: () => Promise<void>;
   fetchCurrentDay: () => Promise<void>;
-  startTask: () => Promise<void>; // Nueva función para empezar tarea
+  startTask: () => Promise<void>;
   completeTask: () => Promise<void>;
   completeSubtask: () => Promise<void>;
   updateSubtaskTitle: (subtaskId: string, newTitle: string) => Promise<void>;
+  updateTimer: (elapsedSeconds: number, state: TimerState) => Promise<void>;
+  pauseTimer: () => Promise<void>;
+  resumeTimer: () => Promise<void>;
+  tickTimer: (newSeconds: number) => void;
 }
 
 export interface PaymentContextType {


### PR DESCRIPTION
Se añade una nueva funcionalidad de timer de 45 minutos para la tarea semanal específica 'Mac'.

Características principales:
- El timer se inicia cuando la tarea 'Mac' comienza.
- El estado del timer (tiempo transcurrido, estado de pausa/ejecución) se persiste en el backend, por lo que no se resetea al recargar la página.
- El timer puede ser pausado y reanudado por el usuario.
- La tarea 'Mac' se completa automáticamente cuando el timer llega a los 45 minutos.
- Se ha refactorizado el componente `TaskTimer` para ser controlado por el estado global del `WeeklyContext`, mejorando la separación de responsabilidades.
- Se ha optimizado la comunicación con el backend para que el estado del timer solo se guarde en eventos clave (inicio, pausa, reanudación, finalización) en lugar de en cada segundo.